### PR TITLE
Remove erroneous space in Markdown syntax

### DIFF
--- a/nb/0-1.md
+++ b/nb/0-1.md
@@ -32,7 +32,7 @@ Det var det for det grunnleggende - hvis Xcode fortsatt ikke har lastet ned, så
 
 Når du starter Xcode, ser du noe som på bildet nedenfor. Se etter "Get started with a playground" knappen nederst til venstre, og klikk på den.
 
-![Når du starter Xcode, blir du spurt om hva slags prosjekt du vil lage. Vennligst velg Get Started with a playground.] (0-1.png)
+![Når du starter Xcode, blir du spurt om hva slags prosjekt du vil lage. Vennligst velg Get Started with a playground.](0-1.png)
 
 Xcode vil spørre deg om du vil opprette en playground for iOS eller macOS, men det spiller ingen rolle her - denne innføringen er nesten utelukkende om språket Swift, uten brukergrensesnitt komponenter. For å unngå problemer, la "iOS" være valget av plattform. Du vil se en liste over playground maler som du kan velge ifra, men vi skal begynne i det små her, så velg Blank.
 


### PR DESCRIPTION
The erroneous space in the Markdown image syntax caused the image not to show up.