### PR TITLE
Corrected a misleading use of parenthesis, dicussed with the translator.

### DIFF
--- a/de/0-5.md
+++ b/de/0-5.md
@@ -7,7 +7,7 @@ Lösche deinen ganzen Code aus deinem Playground und behalte nur diese Zeile:
 
     var name = "Tim McGraw"
 
-Angenommen wir wollen eine Nachricht ausgeben die den Namen des Users enthält, dann macht String Interpolation dies einfach: Schreibe einen Backslash (`\`) gefolgt von der Variable in runden Klammern. Dein Code sieht dann folgendermaßen aus:
+Angenommen wir wollen eine Nachricht ausgeben die den Namen des Users enthält, dann macht String Interpolation dies einfach: Schreibe einen Backslash `\` gefolgt von der Variable in runden Klammern. Dein Code sieht dann folgendermaßen aus:
 
     var name = "Tim McGraw"
     "Your name is \(name)"


### PR DESCRIPTION
To explain "\(x)"  it was not useful to also use parenthesis to explain the char `\` aka Backslash